### PR TITLE
Add travis builds for current LTS Node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: node_js
 node_js:
   - "10"
+  - "12"
+  - "14"


### PR DESCRIPTION
This commit adds configuration to Travis to run the builds and tests for Node 12 and 14, in addition to Node 10.

Node 10 should be removed in the future as it is no longer an LTS.