### PR TITLE
[CHORE] Bump the Node version in Github actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: "12"
+          node-version: "16"
 
       # Speed up subsequent runs with caching
       - name: Cache node modules
@@ -28,6 +28,7 @@ jobs:
       - name: Install Dependencies
         run: npm install
 
+      # Lint the code
       - name: Lint
         run: npm run lint
 


### PR DESCRIPTION
This commit bumps the node version used in Github actions from 12 -> 16.
This represents the current LTS.
