### PR TITLE
[FEAT] Migrate from the Puppeteer library to the Playwright library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "eslint-plugin-node": "^11.1.0",
         "jest": "^28.1.1",
         "jest-mock-extended": "^2.0.6",
+        "playwright": "^1.23.2",
         "ts-jest": "^28.0.5",
         "typescript": "^4.7.4"
       },
@@ -5475,6 +5476,34 @@
         "node": ">=8"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.23.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.23.2.tgz",
+      "integrity": "sha512-c7nyyuDRifGBUNb+/zZh4AjyQXQISVHZY2cpHCsSIWueZNtY7q6Qfv0hJbVdtJhWSGgcix0hmES30l5jlPmy5Q==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "playwright-core": "1.23.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.23.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.23.2.tgz",
+      "integrity": "sha512-UGbutIr0nBALDHWW/HcXfyK6ZdmefC99Moo4qyTr89VNIkYZuDrW8Sw554FyFUamcFSdKOgDPk6ECSkofGIZjQ==",
+      "dev": true,
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -10681,6 +10710,21 @@
       "requires": {
         "find-up": "^4.0.0"
       }
+    },
+    "playwright": {
+      "version": "1.23.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.23.2.tgz",
+      "integrity": "sha512-c7nyyuDRifGBUNb+/zZh4AjyQXQISVHZY2cpHCsSIWueZNtY7q6Qfv0hJbVdtJhWSGgcix0hmES30l5jlPmy5Q==",
+      "dev": true,
+      "requires": {
+        "playwright-core": "1.23.2"
+      }
+    },
+    "playwright-core": {
+      "version": "1.23.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.23.2.tgz",
+      "integrity": "sha512-UGbutIr0nBALDHWW/HcXfyK6ZdmefC99Moo4qyTr89VNIkYZuDrW8Sw554FyFUamcFSdKOgDPk6ECSkofGIZjQ==",
+      "dev": true
     },
     "prelude-ls": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paparazzi-cli",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "engines": {
     "node": ">=16.0.0"
   },
@@ -53,6 +53,7 @@
     "eslint-plugin-node": "^11.1.0",
     "jest": "^28.1.1",
     "jest-mock-extended": "^2.0.6",
+    "playwright": "^1.23.2",
     "ts-jest": "^28.0.5",
     "typescript": "^4.7.4"
   }

--- a/src/lib/lib.spec.ts
+++ b/src/lib/lib.spec.ts
@@ -1,5 +1,5 @@
 import { mock } from "jest-mock-extended";
-import type { Page } from "puppeteer";
+import type { Page } from "playwright";
 import { screenshot } from "./lib"
 import { PaparazziProps } from "./PaparazziProps";
 

--- a/src/lib/lib.ts
+++ b/src/lib/lib.ts
@@ -1,4 +1,4 @@
-import { Page } from "puppeteer";
+import { Page } from "playwright";
 import { PaparazziProps } from "./PaparazziProps";
 import SetQueue from "./SetQueue";
 
@@ -11,7 +11,7 @@ export async function screenshot(page: Page, url: string, args: PaparazziProps) 
 
 export async function addLinks(page: Page, q: SetQueue<string>, allowedHosts: Array<string>, args: PaparazziProps) {
   //Get all the links on the page, ignore empty href.
-  const links = await page.$$eval("a", elements => { return elements.map(a => (a as HTMLLinkElement).href).filter(a => a) });
+  const links = await page.$$eval("a", elements => { return elements.map(a => a.href).filter(a => a) });
 
   for (const l of links) {
     try {


### PR DESCRIPTION
This commit removes the Puppeteer API calls in favour of using Playwright.
These changes represent the minimal migration possible, and does not guarantee the Playwright code is optimal.
