### PR TITLE
[FEAT] Add a flag to not take screenshots of anchor links

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "pwa-node",
+            "request": "launch",
+            "name": "Launch Program",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "program": "${workspaceFolder}/dist/lib/index.js",
+            "outFiles": [
+                "${workspaceFolder}/**/*.js"
+            ]
+        }
+    ]
+}

--- a/README.MD
+++ b/README.MD
@@ -30,6 +30,7 @@ FLAGS
   --allow-all-hosts     Take screenshots of any HTTP host, not just those specified
   --device=<value>      Emulate this device when making HTTP requests
   --full-page           Ensure all content on page is included in screenshot (will override width and height settings)
+  --ignore-anchors      Don't take screenshots of each separate anchor link
   --list-devices        List all devices which can be emulated and exit (Note this is a long list)
   --user-agent=<value>  User Agent to spoof whilst making HTTP requests
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paparazzi-cli",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "engines": {
     "node": ">=16.0.0"
   },

--- a/src/lib/PaparazziProps.ts
+++ b/src/lib/PaparazziProps.ts
@@ -44,6 +44,10 @@ export const FLAGS = {
     "allow-all-hosts": Flags.boolean({
         description: "Take screenshots of any HTTP host, not just those specified",
         default: false
+    }),
+    "ignore-anchors": Flags.boolean({
+        description: "Don't take screenshots of each separate anchor link",
+        default: false
     })
 }
 

--- a/src/lib/lib.spec.ts
+++ b/src/lib/lib.spec.ts
@@ -1,7 +1,8 @@
-import { mock } from "jest-mock-extended";
+import { calledWithFn, mock, MockProxy } from "jest-mock-extended";
 import type { Page } from "playwright";
-import { screenshot } from "./lib"
+import { addLinks, screenshot } from "./lib"
 import { PaparazziProps } from "./PaparazziProps";
+import SetQueue from "./SetQueue";
 
 const defaultConfig: PaparazziProps = {
   output: "./images",
@@ -13,7 +14,8 @@ const defaultConfig: PaparazziProps = {
   "allow-all-hosts": false,
   "list-devices": false,
   "user-agent": undefined,
-  device: undefined
+  device: undefined,
+  "ignore-anchors": false
 };
 
 describe("screenshot()", () => {
@@ -21,10 +23,98 @@ describe("screenshot()", () => {
     const page = mock<Page>();
     const url = "fake/url";
 
-    await screenshot(page, url, defaultConfig);
+    await screenshot({
+      page: page,
+      url: url,
+      baseProps: defaultConfig
+    });
 
     expect(page.goto).toBeCalledWith(url);
     expect(page.waitForTimeout).toBeCalledWith(defaultConfig.delay);
     expect(page.screenshot).toBeCalledTimes(1);
   })
 });
+
+describe("addLinks()", () => {
+  let setQueue: MockProxy<SetQueue<string>>;
+  let page: MockProxy<Page>;
+  const linksToScrape = ["http://example.com", "http://example.com/another", "http://example.com/another#anchor"];
+
+  beforeEach(() => {
+    setQueue = mock<SetQueue<string>>();
+    page = mock<Page>();
+  })
+
+  test("should add scraped links to the queue", async () => {
+    page.$$eval.mockImplementation(async () => linksToScrape);
+
+    await addLinks({
+      page: page,
+      queue: setQueue,
+      allowedHosts: [
+        "example.com"
+      ],
+      baseProps: defaultConfig
+    })
+
+    for (const link of linksToScrape) {
+      expect(setQueue.push).toBeCalledWith(link);
+    }
+  })
+
+  test("should not add links if they are not in allowedHosts", async () => {
+    page.$$eval.mockImplementation(async () => linksToScrape);
+
+    await addLinks({
+      page: page,
+      queue: setQueue,
+      allowedHosts: [
+        "differentExample.com"
+      ],
+      baseProps: defaultConfig
+    })
+
+    expect(setQueue.push).toBeCalledTimes(0);
+  })
+
+  test("should add links regardless of host if allowAllHosts is true", async () => {
+    page.$$eval.mockImplementation(async () => linksToScrape);
+
+    await addLinks({
+      page: page,
+      queue: setQueue,
+      allowedHosts: [
+        "differentExample.com"
+      ],
+      baseProps: {
+        ...defaultConfig,
+        "allow-all-hosts": true
+      }
+    })
+
+    for (const link of linksToScrape) {
+      expect(setQueue.push).toBeCalledWith(link);
+    }
+  })
+
+  test("should strip hashes from links before adding to the queue when ignoreAnchors is true", async () => {
+    page.$$eval.mockImplementation(async () => linksToScrape);
+
+    await addLinks({
+      page: page,
+      queue: setQueue,
+      allowedHosts: [
+        "example.com"
+      ],
+      baseProps: {
+        ...defaultConfig,
+        "ignore-anchors": true
+      }
+    })
+
+    expect(setQueue.push).toBeCalledTimes(3);
+    expect(setQueue.push).nthCalledWith(1, "http://example.com");
+    expect(setQueue.push).nthCalledWith(2, "http://example.com/another");
+    expect(setQueue.push).nthCalledWith(3, "http://example.com/another");
+  })
+})


### PR DESCRIPTION
This commit adds a new `--ignore-anchors` flag to the CLI, which tells the tool to strip anchors before scraping links.
This means that you will only get one screenshot per path, rather than one screenshot per anchor on the path.
This functionality will cause issues with sites that use virtual routing via anchor links, so is disabled by default.
